### PR TITLE
Use a different alpine linux version per ansible version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "feature/alpineVersionPerAnsibleVersion"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       matrix:
         versions:
-          - { ansible: 2.10.0, alpine: 3.13 }
-          - { ansible: 3.4.0, alpine: 3.15 }
-          - { ansible: 4.8.0, alpine: 3.15 }
-          - { ansible: 4.10.0, alpine: 3.15 }
-          - { ansible: 5.5.0, alpine: 3.16 }
-          - { ansible: 5.8.0, alpine: 3.16 }
-          - { ansible: 5.10.0, alpine: 3.16 }
-          - { ansible: 6.7.0, alpine: 3.16 }
-          - { ansible: 7.7.0, alpine: 3.18 }
-          - { ansible: 8.7.0, alpine: 3.18 }
-          - { ansible: 9.7.0, alpine: 3.20 }
-          - { ansible: 10.1.0, alpine: 3.20 }
+          - { ansible: "2.10.0", alpine: "3.13" }
+          - { ansible: "3.4.0", alpine: "3.15" }
+          - { ansible: "4.8.0", alpine: "3.15" }
+          - { ansible: "4.10.0", alpine: "3.15" }
+          - { ansible: "5.5.0", alpine: "3.16" }
+          - { ansible: "5.8.0", alpine: "3.16" }
+          - { ansible: "5.10.0", alpine: "3.16" }
+          - { ansible: "6.7.0", alpine: "3.16" }
+          - { ansible: "7.7.0", alpine: "3.18" }
+          - { ansible: "8.7.0", alpine: "3.18" }
+          - { ansible: "9.7.0", alpine: "3.20" }
+          - { ansible: "10.1.0", alpine: "3.20" }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,18 @@ jobs:
     strategy:
       matrix:
         versions:
-          - { ansible: 2.10.0, alpine: 3.15 }
+          - { ansible: 2.10.0, alpine: 3.13 }
           - { ansible: 3.4.0, alpine: 3.15 }
           - { ansible: 4.8.0, alpine: 3.15 }
           - { ansible: 4.10.0, alpine: 3.15 }
-          - { ansible: 5.5.0, alpine: 3.15 }
-          - { ansible: 5.8.0, alpine: 3.15 }
-          - { ansible: 5.10.0, alpine: 3.15 }
-          - { ansible: 6.7.0, alpine: 3.15 }
-          - { ansible: 7.7.0, alpine: 3.15 }
-          - { ansible: 8.7.0, alpine: 3.15 }
-          - { ansible: 9.7.0, alpine: 3.15 }
-          - { ansible: 10.1.0, alpine: 3.15 }
+          - { ansible: 5.5.0, alpine: 3.16 }
+          - { ansible: 5.8.0, alpine: 3.16 }
+          - { ansible: 5.10.0, alpine: 3.16 }
+          - { ansible: 6.7.0, alpine: 3.16 }
+          - { ansible: 7.7.0, alpine: 3.18 }
+          - { ansible: 8.7.0, alpine: 3.18 }
+          - { ansible: 9.7.0, alpine: 3.20 }
+          - { ansible: 10.1.0, alpine: 3.20 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,19 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - 2.10.0
-          - 3.4.0
-          - 4.8.0
-          - 4.10.0
-          - 5.5.0
-          - 5.8.0
-          - 5.10.0
-          - 6.7.0
-          - 7.7.0
-          - 8.7.0
-          - 9.7.0
-          - 10.1.0
+        versions:
+          - { ansible: 2.10.0, alpine: 3.15 }
+          - { ansible: 3.4.0, alpine: 3.15 }
+          - { ansible: 4.8.0, alpine: 3.15 }
+          - { ansible: 4.10.0, alpine: 3.15 }
+          - { ansible: 5.5.0, alpine: 3.15 }
+          - { ansible: 5.8.0, alpine: 3.15 }
+          - { ansible: 5.10.0, alpine: 3.15 }
+          - { ansible: 6.7.0, alpine: 3.15 }
+          - { ansible: 7.7.0, alpine: 3.15 }
+          - { ansible: 8.7.0, alpine: 3.15 }
+          - { ansible: 9.7.0, alpine: 3.15 }
+          - { ansible: 10.1.0, alpine: 3.15 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,7 +40,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           build-args: |
-            ANSIBLE_VERSION=${{ matrix.image }}
+            ANSIBLE_VERSION=${{ matrix.versions.ansible }}
+            BASE_IMAGE=alpine:${{ matrix.versions.alpine }}
           platforms: linux/amd64, linux/arm64
           push: true
-          tags: rareloop/ansible:${{ matrix.image }}
+          tags: rareloop/ansible:${{ matrix.versions.ansible }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "feature/alpineVersionPerAnsibleVersion"
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:latest
+ARG BASE_IMAGE=alpine:3.15
+
+FROM $BASE_IMAGE
 
 # Use Ansible 4.8.0 by default
 ARG ANSIBLE_VERSION=4.8.0
@@ -7,12 +9,13 @@ ENV ENV_ANSIBLE_VERSION=$ANSIBLE_VERSION
 # Installs Dependencies
 # Note: Apply fix from Jeff that allows pip install to work without --break-system-packages
 # https://www.jeffgeerling.com/blog/2023/how-solve-error-externally-managed-environment-when-installing-pip3
-RUN apk add --update python3 py-pip openssl ca-certificates bash git sudo zip \
-    && apk add --update --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base \
-    && find /usr/lib/python* | grep EXTERNALLY-MANAGED | xargs rm \
-    && pip install --upgrade pip cffi \
-    && pip install --upgrade pycrypto pywinrm \
-    && apk add --update sshpass openssh-client rsync
+RUN apk add --update python3 py-pip openssl ca-certificates bash git sudo zip sshpass openssh-client rsync \
+    && apk add --update --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base
+
+# Pip Dependencies
+# RUN find /usr/lib/python* | grep EXTERNALLY-MANAGED | xargs rm \
+RUN pip install --upgrade pip cffi \
+    && pip install --upgrade pycrypto pywinrm
 
 # Install Ansible
 RUN pip install ansible==$ENV_ANSIBLE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ ARG ANSIBLE_VERSION=4.8.0
 ENV ENV_ANSIBLE_VERSION=$ANSIBLE_VERSION
 
 # Installs Dependencies
-# Note: Apply fix from Jeff that allows pip install to work without --break-system-packages
-# https://www.jeffgeerling.com/blog/2023/how-solve-error-externally-managed-environment-when-installing-pip3
 RUN apk add --update python3 py-pip openssl ca-certificates bash git sudo zip sshpass openssh-client rsync \
     && apk add --update --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base
 
+# Note: Apply fix from Jeff that allows pip install to work without --break-system-packages
+# https://www.jeffgeerling.com/blog/2023/how-solve-error-externally-managed-environment-when-installing-pip3
+RUN find /usr/lib/python* | grep EXTERNALLY-MANAGED | xargs -r rm 
+
 # Pip Dependencies
-# RUN find /usr/lib/python* | grep EXTERNALLY-MANAGED | xargs rm \
 RUN pip install --upgrade pip cffi \
     && pip install --upgrade pycrypto pywinrm
 

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
+# You can get an idea for which alpine version you need by looking here:
+# https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.15&repo=&arch=&maintainer=
+#
+# You can check what Python3 version is available for which Alpine Linux version and adjust accordingly.
+#
+# You should check https://endoflife.date/ansible to consider which Python version is suitable.
 
-# ANSIBLE_VERSION=4.8.0
-# ALPINE_LINUX_VERSION=3.15
-ANSIBLE_VERSION=2.10.0
-ALPINE_LINUX_VERSION=3.15
-
-if [ -n "$1" ]; then
-    ANSIBLE_VERSION=$1;
-    shift 1
-fi
-
-# Ansible 4.8.0
-# (docker build --build-arg ANSIBLE_VERSION=${ANSIBLE_VERSION} --build-arg ALPINE_LINUX_VERSION=$ALPINE_LINUX_VERSION. -t rareloop/ansible:${ANSIBLE_VERSION} && docker push rareloop/ansible:${ANSIBLE_VERSION})
-docker build --build-arg ANSIBLE_VERSION=${ANSIBLE_VERSION} --build-arg BASE_IMAGE=alpine:${ALPINE_LINUX_VERSION} . -t rareloop-local/ansible:${ANSIBLE_VERSION}
+docker build --build-arg ANSIBLE_VERSION=2.10.0 --build-arg BASE_IMAGE=alpine:3.13 . -t rareloop-local/ansible:2.10.0
+docker build --build-arg ANSIBLE_VERSION=3.4.0 --build-arg BASE_IMAGE=alpine:3.15 . -t rareloop-local/ansible:3.4.0
+docker build --build-arg ANSIBLE_VERSION=4.8.0 --build-arg BASE_IMAGE=alpine:3.15 . -t rareloop-local/ansible:4.8.0
+docker build --build-arg ANSIBLE_VERSION=4.10.0 --build-arg BASE_IMAGE=alpine:3.15 . -t rareloop-local/ansible:4.10.0
+docker build --build-arg ANSIBLE_VERSION=5.5.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:5.5.0
+docker build --build-arg ANSIBLE_VERSION=5.8.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:5.8.0
+docker build --build-arg ANSIBLE_VERSION=5.10.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:5.10.0
+docker build --build-arg ANSIBLE_VERSION=6.7.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:6.7.0
+docker build --build-arg ANSIBLE_VERSION=7.7.0 --build-arg BASE_IMAGE=alpine:3.18 . -t rareloop-local/ansible:7.7.0
+docker build --build-arg ANSIBLE_VERSION=8.7.0 --build-arg BASE_IMAGE=alpine:3.18 . -t rareloop-local/ansible:8.7.0
+docker build --build-arg ANSIBLE_VERSION=9.7.0 --build-arg BASE_IMAGE=alpine:3.20 . -t rareloop-local/ansible:9.7.0
+docker build --build-arg ANSIBLE_VERSION=10.1.0 --build-arg BASE_IMAGE=alpine:3.20 . -t rareloop-local/ansible:10.1.0
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-ANSIBLE_VERSION=4.8.0
+# ANSIBLE_VERSION=4.8.0
+# ALPINE_LINUX_VERSION=3.15
+ANSIBLE_VERSION=2.10.0
+ALPINE_LINUX_VERSION=3.15
 
 if [ -n "$1" ]; then
     ANSIBLE_VERSION=$1;
@@ -8,5 +11,6 @@ if [ -n "$1" ]; then
 fi
 
 # Ansible 4.8.0
-(docker build --build-arg ANSIBLE_VERSION=${ANSIBLE_VERSION} . -t rareloop/ansible:${ANSIBLE_VERSION} && docker push rareloop/ansible:${ANSIBLE_VERSION})
+# (docker build --build-arg ANSIBLE_VERSION=${ANSIBLE_VERSION} --build-arg ALPINE_LINUX_VERSION=$ALPINE_LINUX_VERSION. -t rareloop/ansible:${ANSIBLE_VERSION} && docker push rareloop/ansible:${ANSIBLE_VERSION})
+docker build --build-arg ANSIBLE_VERSION=${ANSIBLE_VERSION} --build-arg BASE_IMAGE=alpine:${ALPINE_LINUX_VERSION} . -t rareloop-local/ansible:${ANSIBLE_VERSION}
 

--- a/build.sh
+++ b/build.sh
@@ -6,16 +6,26 @@
 #
 # You should check https://endoflife.date/ansible to consider which Python version is suitable.
 
-docker build --build-arg ANSIBLE_VERSION=2.10.0 --build-arg BASE_IMAGE=alpine:3.13 . -t rareloop-local/ansible:2.10.0
-docker build --build-arg ANSIBLE_VERSION=3.4.0 --build-arg BASE_IMAGE=alpine:3.15 . -t rareloop-local/ansible:3.4.0
-docker build --build-arg ANSIBLE_VERSION=4.8.0 --build-arg BASE_IMAGE=alpine:3.15 . -t rareloop-local/ansible:4.8.0
-docker build --build-arg ANSIBLE_VERSION=4.10.0 --build-arg BASE_IMAGE=alpine:3.15 . -t rareloop-local/ansible:4.10.0
-docker build --build-arg ANSIBLE_VERSION=5.5.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:5.5.0
-docker build --build-arg ANSIBLE_VERSION=5.8.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:5.8.0
-docker build --build-arg ANSIBLE_VERSION=5.10.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:5.10.0
-docker build --build-arg ANSIBLE_VERSION=6.7.0 --build-arg BASE_IMAGE=alpine:3.16 . -t rareloop-local/ansible:6.7.0
-docker build --build-arg ANSIBLE_VERSION=7.7.0 --build-arg BASE_IMAGE=alpine:3.18 . -t rareloop-local/ansible:7.7.0
-docker build --build-arg ANSIBLE_VERSION=8.7.0 --build-arg BASE_IMAGE=alpine:3.18 . -t rareloop-local/ansible:8.7.0
-docker build --build-arg ANSIBLE_VERSION=9.7.0 --build-arg BASE_IMAGE=alpine:3.20 . -t rareloop-local/ansible:9.7.0
-docker build --build-arg ANSIBLE_VERSION=10.1.0 --build-arg BASE_IMAGE=alpine:3.20 . -t rareloop-local/ansible:10.1.0
+# Using two parallel arrays to match up an ansible version to its base alpine image
+# MacOS doesn't come with a high enough bash version to use bash associative arrays.
+ANSIBLE_VERSIONS=("2.10.0" "3.4.0" "4.8.0" "4.10.0" "5.5.0" "5.8.0" "5.10.0" "6.7.0" "7.7.0" "8.7.0" "9.7.0" "10.1.0")
+BASE_IMAGES=("alpine:3.13" "alpine:3.15" "alpine:3.15" "alpine:3.15" "alpine:3.16" "alpine:3.16" "alpine:3.16" "alpine:3.16" "alpine:3.18" "alpine:3.18" "alpine:3.20" "alpine:3.20")
 
+LENGTH=${#ANSIBLE_VERSIONS[@]}
+
+for (( i=0; i<${LENGTH}; i++ )); do
+    ANSIBLE_VERSION=${ANSIBLE_VERSIONS[$i]}
+    BASE_IMAGE=${BASE_IMAGES[$i]}
+
+    echo "=====================";
+    echo "Ansible Version: ${ANSIBLE_VERSION}";
+    echo "Base Image: ${BASE_IMAGE}";
+    echo "=====================";
+
+    docker build --build-arg ANSIBLE_VERSION="${ANSIBLE_VERSION}" --build-arg BASE_IMAGE="${BASE_IMAGE}" . -t rareloop-local/ansible:"${ANSIBLE_VERSION}"
+    docker run -it --rm rareloop-local/ansible:"${ANSIBLE_VERSION}" ansible --version
+
+    echo "";
+    echo "";
+    echo "";
+done


### PR DESCRIPTION
The Ansible install is very reliant on the python version that's available in a given alpine linux versions repos.

To work around this we'll couple an alpine linux version to an ansible version.